### PR TITLE
fixed CellFie dir in buildsuites.xml

### DIFF
--- a/buildsuites.xml
+++ b/buildsuites.xml
@@ -122,8 +122,8 @@
         </fileset>
 
         <!-- CellFie -->
-        <fileset id="ShortCellFieTests" dir="${git.parentdir}/MethylationCNVAnalysis/gpunit" >
-            <!-- CellFie - v1.2 -->
+        <fileset id="ShortCellFieTests" dir="${git.parentdir}/CellFie/gpunit" >
+            <!-- CellFie - v3.x -->
             <include name="nightly*.yml" />
         </fileset>
 
@@ -161,7 +161,7 @@
         <clone-repo git.repo.name="VoomNormalize" />
         <clone-repo git.repo.name="TopHat" />
         <clone-repo git.repo.name="txt2odf" />
-        <clone-repo git.repo.name="TCGAImporter" /> 
+        <clone-repo git.repo.name="TCGAImporter" />
         <!-- Starting to add chronologically rather than alphabetically -->
         <clone-repo git.repo.name="ABasicModule" />
         <clone-repo git.repo.name="MethylationCNVAnalysis" />


### PR DESCRIPTION
This pull request fixes the directory for the CellFie module unit tests. It also apparently includes one whitespace deletion that my editor did on line 164. 